### PR TITLE
perf(keyword): Don't pre-calculate key assert msg

### DIFF
--- a/lib/keyword/extra.ex
+++ b/lib/keyword/extra.ex
@@ -88,18 +88,19 @@ defmodule Keyword.Extra do
   """
   @spec assert_key!(t, key, keyword) :: :ok | no_return
   def assert_key!(list, key, opts \\ []) do
-    message =
+    message = fn ->
       Keyword.get(opts, :message, "#{inspect(key)} is required to be in keyword list.")
+    end
 
     allow_nil_value? =
       Keyword.get(opts, :allow_nil_value, true)
 
     case Keyword.fetch(list, key) do
       {:ok, nil} when not allow_nil_value? ->
-        raise(ArgumentError, message)
+        raise(ArgumentError, message.())
 
       :error ->
-        raise(ArgumentError, message)
+        raise(ArgumentError, message.())
 
       _ -> :ok
     end


### PR DESCRIPTION
This is a super crazy tight inner-loop optimization, but this function
is getting called a *ton* by some of the internal stuff so this should
have enough of an impact to make it worth it