### PR TITLE
feat(stream): Add Stream.Extra.sorted_merge

### DIFF
--- a/lib/stream/extra.ex
+++ b/lib/stream/extra.ex
@@ -84,4 +84,139 @@ defmodule Stream.Extra do
     end)
   end
 
+
+  @doc """
+  Merges two sorted streams into one sorted stream.
+
+  `comparator` may optionally be passed as a function which will compare two arbitrary elements of
+  the stream for order. Defaults to `<=`
+
+  ## Examples
+
+      iex> Stream.Extra.sorted_merge(
+      ...>   [1, 3, 6, 7],
+      ...>   [2, 4, 5, 8, 9, 10]
+      ...> ) |> Enum.to_list()
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+      iex> Stream.Extra.sorted_merge(
+      ...>   [7, 6, 3, 1],
+      ...>   [10, 9, 8, 5, 2],
+      ...>   &Kernel.>=/2
+      ...> ) |> Enum.to_list()
+      [10, 9, 8, 7, 6, 5, 3, 2, 1]
+
+  """
+  @spec sorted_merge(Enumerable.t, Enumerable.t, ((any, any) -> boolean)) :: Enumerable.t
+  def sorted_merge(enum_a, enum_b, comparator) when is_function(comparator, 2) do
+    sorted_merge([enum_a, enum_b], comparator)
+  end
+
+  @doc """
+  Merges any number of sorted streams into one sorted stream.
+
+  `comparator` may optionally be passed as a function which will compare two arbitrary elements of
+  the stream for order. Defaults to `<=`
+
+  ## Examples
+
+      iex> Stream.Extra.sorted_merge([
+      ...>   [1, 3, 6, 7],
+      ...>   [4, 8, 9],
+      ...>   [2, 5, 8]
+      ...> ]) |> Enum.to_list()
+      [1, 2, 3, 4, 5, 6, 7, 8, 8, 9]
+
+      iex> Stream.Extra.sorted_merge([
+      ...>   [7, 6, 3, 1],
+      ...>   [9, 8, 4],
+      ...>   [8, 5, 2]
+      ...> ], &Kernel.>=/2) |> Enum.to_list()
+      [9, 8, 8, 7, 6, 5, 4, 3, 2, 1]
+
+  """
+  @spec sorted_merge([Enumerable.t], ((any, any) -> boolean)) :: Enumerable.t
+  def sorted_merge(enums, comparator) when is_list(enums) and is_function(comparator, 2) do
+    enum_funs =
+      Enum.map(enums, fn enum ->
+        &Enumerable.reduce(enum, &1, fn x, [] -> {:suspend, [x]} end)
+      end)
+
+    &do_sorted_merge(enum_funs, &1, &2, comparator)
+  end
+
+  def sorted_merge(enum_a, enum_b), do: sorted_merge([enum_a, enum_b], &Kernel.<=/2)
+  def sorted_merge(enums) when is_list(enums), do: sorted_merge(enums, &Kernel.<=/2)
+
+  defp do_sorted_merge(enums, {:halt, acc}, _callback, _comparator) do
+    # If the stream that's consuming us tells us to halt, tell all our enums to halt and return the
+    # current accumulator
+    do_sorted_merge_close(enums)
+    {:halted, acc}
+  end
+
+  defp do_sorted_merge(enums, {:suspend, acc}, callback, comparator) do
+    # If the stream that's consuming us tells us to suspend, save a continuation thunk and return
+    # that and the current accumulator
+    {:suspended, acc, &do_sorted_merge(enums, &1, callback, comparator)}
+  end
+
+  defp do_sorted_merge(enums, {:cont, acc}, callback, comparator) do
+    do_sorted_merge_next_element(enums, acc, callback, comparator)
+  catch
+    kind, reason ->
+      stacktrace = System.stacktrace
+      # If something throws, make sure to close all upstream enums
+      do_sorted_merge_close(enums)
+      :erlang.raise(kind, reason, stacktrace)
+  else
+    {:next, buffer, acc}  -> do_sorted_merge(buffer, acc, callback, comparator)
+    {:done, _acc} = other -> other
+  end
+
+  defp do_sorted_merge_next_element([last_fun], acc, callback, _comparator) do
+    # If we're down to only one enumerator left, just consume it until it's done
+    case last_fun.({:cont, []}) do
+      {:suspended, [elem], next_fun} -> {:next, [next_fun], callback.(elem, acc)}
+      {:done, []} -> {:done, acc}
+    end
+  end
+
+  defp do_sorted_merge_next_element(enums, acc, callback, comparator) do
+    {next, idx_taken, next_fun_for_idx, finished_enums} =
+      # Walk through each of the enums...
+      enums
+      # Peeking the next element...
+      |> Stream.map(& &1.({:cont, []}))
+      # And retaining:
+      # - the current minimum value taken,
+      # - the index of the enum that yielded that minimum value,
+      # - the next thunk for the enum that yielded that minimum value,
+      # - and a list of the indexes of the enums which have finished
+      |> Stream.with_index()
+      |> Enum.reduce({:"$init", nil, nil, []}, fn
+        {{:suspended, [elem], next_fun}, idx}, {min, _, _, finished_enums} = current ->
+          if min == :"$init" or comparator.(elem, min) do
+            {elem, idx, next_fun, finished_enums}
+          else
+            current
+          end
+        {{:done, []}, idx}, {min, idx_taken, fun, finished_enums} ->
+          {min, idx_taken, fun, [idx | finished_enums]}
+      end)
+
+      enums =
+        enums
+        # After we're done, replace the enum that gave us the smallest value with its next thunk...
+        |> List.replace_at(idx_taken, next_fun_for_idx)
+        # and remove all the enums that have finished.
+        |> Enum.Extra.fold(finished_enums, &List.delete_at(&2, &1))
+
+      {:next, enums, callback.(next, acc)}
+  end
+
+  defp do_sorted_merge_close(enums) do
+    Enum.each(enums, fn fun -> fun.({:halt, []}) end)
+  end
+
 end

--- a/test/stream/extra_test.exs
+++ b/test/stream/extra_test.exs
@@ -4,6 +4,7 @@ defmodule Stream.ExtraTest do
   use ExUnit.Case, async: true
 
   import ExUnit.CaptureLog
+  import ExUnit.CaptureIO
 
   doctest Stream.Extra
 
@@ -57,6 +58,26 @@ defmodule Stream.ExtraTest do
       assert capture_log(fn ->
         enum |> Stream.Extra.unwrap_oks(log_errors: true) |> Stream.run
       end) =~ "Encountered :error tuple. {:error, 2}"
+    end
+  end
+
+  describe "sorted_merge/2" do
+    test "only enumerates each stream once" do
+      list_a =
+        [1, 3, 6, 7]
+        |> Stream.each(&IO.puts/1)
+      list_b =
+        [2, 4, 5, 8, 9, 10]
+        |> Stream.each(&IO.puts/1)
+
+      captured =
+        capture_io(fn ->
+          assert [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] ==
+            Stream.Extra.sorted_merge(list_a, list_b) |> Enum.to_list()
+        end)
+
+      assert MapSet.new(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", ""]) ==
+        captured |> String.split("\n") |> MapSet.new()
     end
   end
 

--- a/test/stream/extra_test.exs
+++ b/test/stream/extra_test.exs
@@ -79,6 +79,35 @@ defmodule Stream.ExtraTest do
       assert MapSet.new(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", ""]) ==
         captured |> String.split("\n") |> MapSet.new()
     end
+
+    test "works with halting streams" do
+      table_a =
+        :ets.new(:table_a, [:ordered_set])
+      table_b =
+        :ets.new(:table_a, [:ordered_set])
+
+      Enum.each([1, 3, 6, 7], &:ets.insert(table_a, {&1, &1}))
+      Enum.each([2, 4, 5, 8, 9, 10], &:ets.insert(table_b, {&1, &1}))
+
+      assert [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] ==
+        Stream.Extra.sorted_merge(
+          ETS.Extra.stream_keys(table_a),
+          ETS.Extra.stream_keys(table_b)
+        ) |> Enum.to_list
+    end
+
+    test "works with empty streams" do
+      table_a =
+        :ets.new(:table_a, [:ordered_set])
+      table_b =
+        :ets.new(:table_a, [:ordered_set])
+
+      assert [] ==
+        Stream.Extra.sorted_merge(
+          ETS.Extra.stream_keys(table_a),
+          ETS.Extra.stream_keys(table_b)
+        ) |> Enum.to_list
+    end
   end
 
 end


### PR DESCRIPTION
Add a function which will merge any number of sorted streams into one
sorted stream, optionally with a custom comparator.

The implementation of this function is heavily based on `Stream.zip` in
the stdlib.